### PR TITLE
Fix for geddy install to Windows Cygwin, added fallback for unavailable sudo uid/gid

### DIFF
--- a/geddy-core/scripts/Jakefile.js
+++ b/geddy-core/scripts/Jakefile.js
@@ -21,8 +21,8 @@ var fs = require('fs');
 
 desc('Installs Geddy web framework');
 task('default', [], function () {
-  var uid = process.env.SUDO_UID;
-  var gid = process.env.SUDO_GID;
+  var uid = process.env.SUDO_UID || process.getuid();
+  var gid = process.env.SUDO_GID || process.getgid();
   var cmds = [];
   cmds = [
     'mkdir -p ~/.node_libraries'
@@ -45,8 +45,8 @@ task('default', [], function () {
 
 desc('Uninstalls Geddy web framework');
 task('uninstall', [], function () {
-  var uid = process.env.SUDO_UID;
-  var gid = process.env.SUDO_GID;
+  var uid = process.env.SUDO_UID || process.getuid();
+  var gid = process.env.SUDO_GID || process.getgid();
   var cmds = [];
   cmds = [
     'rm -f /usr/local/bin/geddy*'


### PR DESCRIPTION
Fix for Issue #34:
  http://github.com/mde/geddy/issues/#issue/34

Geddy 'make install' fails under Windows/Cygwin environment because SUDO uid/gid not available in Jakefile.js, so added a fallback to regular user uid/gid.

thanks!
Brev
