### PR TITLE
confirmPassword field

### DIFF
--- a/geddy-core/scripts/Jakefile.js
+++ b/geddy-core/scripts/Jakefile.js
@@ -325,6 +325,14 @@ task('scaffold', [], function (nameParam) {
 
             text += '<div><input type="' + inputType + '" id="' + p + '" name="' + p +
                 '" value="<%= params.' + p + ' || \'\' %>" size="24"/></div>\n';
+
+            if ( inputType === 'password' ) {
+              p = 'confirm' + geddy.util.string.capitalize(p) 
+              text += '<div><label for="' + p + '" id="' + p + '_label">' 
+                   + geddy.util.string.capitalize(p) + '</label></div>'
+                   + '<div><input type="' + inputType + '" id="' + p + '" name="' + p
+                   + '" value="<%= params.' + p + ' || \'\' %>" size="24"/></div>\n';
+            }
             break;
           case 'date':
             text += '</div>\n'


### PR DESCRIPTION
Hi, first of all let me say this is my first git experience so sorry if I did something wrong.
While working through the geddy 2-minute app example I ran into this problem that I was unable to save my snow_dogs using the default scaffolding form because it validated my password against a confirmPassword field which didn't exist.
I hacked the script to create a confirm password field, but I'm not sure if it is an elegant solution. 
