### PR TITLE
Fix/illegal cp flag

### DIFF
--- a/geddy-core/scripts/Jakefile.js
+++ b/geddy-core/scripts/Jakefile.js
@@ -176,7 +176,7 @@ task('resource', [], function (nameParam) {
   var cmds = [
     'mkdir -p ./app/views/' + names.filename.plural
     , 'mkdir -p ./app/views/layouts'
-    , 'cp -u ~/.node_libraries/geddy-core/scripts/gen/views/layout.html.ejs ' +
+    , 'rsync -u ~/.node_libraries/geddy-core/scripts/gen/views/layout.html.ejs ' +
     	'./app/views/layouts/application.html.ejs'    
     , 'cp ~/.node_libraries/geddy-core/scripts/gen/views/add.html.ejs ' +
         './app/views/' + names.filename.plural + '/'


### PR DESCRIPTION
Check out the commit message. I couldn't think of any reason why not to use rsync in this case since the usage of the -u flag replicates cp functionality.

Started this which I'll add actual tests to as I have time :: http://github.com/cookrn/geddy-gen_tests
