### PR TITLE
Fix/restore shebangs

### DIFF
--- a/geddy-core/scripts/geddy
+++ b/geddy-core/scripts/geddy
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Geddy JavaScript Web development framework
 # Copyright 2112 Matthew Eernisse (mde@fleegix.org)
@@ -14,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 SOURCE_DIR=""
 USE_SOURCE=0

--- a/geddy-core/scripts/geddy-gen
+++ b/geddy-core/scripts/geddy-gen
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Geddy JavaScript Web development framework
 # Copyright 2112 Matthew Eernisse (mde@fleegix.org)
@@ -14,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 node ~/.node_libraries/geddy-core/scripts/jake.js -f ~/.node_libraries/geddy-core/scripts/Jakefile $@
 

--- a/geddy-core/scripts/jake
+++ b/geddy-core/scripts/jake
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Geddy JavaScript Web development framework
 # Copyright 2112 Matthew Eernisse (mde@fleegix.org)
@@ -14,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/bash
 
 node ./geddy-core/scripts/jake.js $@
 


### PR DESCRIPTION
Shebangs must be at the top of executables. Probably just a simple overlook when batch adding license text to files.
