### PR TITLE
Method overwriting not only for POST requests.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -270,22 +270,18 @@ var App = function () {
       if (router) {
         urlParams = url.parse(req.url, true).query;
 
-        if (req.method.toUpperCase() == 'POST') {
-          // POSTs may be overridden by the _method param
-          if (urlParams._method) {
-              method = urlParams._method;
-          }
-          // Or x-http-method-override header
-          else if (req.headers['x-http-method-override']) {
-            method = req.headers['x-http-method-override'];
-          }
-          else {
-            method = req.method;
-          }
+        // Method may be overwritten by the _method param
+        if (urlParams._method) {
+          method = urlParams._method;
+        }
+        // Or x-http-method-override header
+        else if (req.headers['x-http-method-override']) {
+          method = req.headers['x-http-method-override'];
         }
         else {
           method = req.method;
         }
+
         // Okay, let's be anal and force all the HTTP verbs to uppercase
         method = method.toUpperCase();
 


### PR DESCRIPTION
This would be useful for direct `<a href="[...]?_method=delete">Delete foo</a>` links.
Don't know if it is usual but would be an enormous help for me.
