### PR TITLE
Use the router to generate redirect urls, when possible.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -402,6 +402,7 @@ var App = function () {
             controller.accessTime = accessTime;
 
             if (typeof controller[params.action] == 'function') {
+              controller.app = self;
               controller.request = reqObj;
               controller.response = resp;
               controller.method = method;

--- a/lib/base_controller.js
+++ b/lib/base_controller.js
@@ -595,7 +595,16 @@ controller.BaseController.prototype = new (function () {
     if (typeof target == 'string') {
       url = target;
     }
-    else {
+    else if (typeof this.app.router.url == 'function') {
+      if (this.name && !target.controller)
+        target.controller = this.name;
+      if (this.params.format && !target.format)
+        target.format = this.params.format;
+
+      url = this.app.router.url(target);
+    }
+
+    if (!url) {
       var contr = target.controller || this.name;
       var act = target.action;
       var ext = target.format || this.params.format;

--- a/lib/routers/regexp_router.js
+++ b/lib/routers/regexp_router.js
@@ -199,6 +199,9 @@ var Router = function () {
   this.url = function (params) {
     var url = false;
 
+    // attempt the stringification with defaults mixed in
+    params = geddy.mixin({controller:'Application', action:'index' }, params);
+
     // iterate through the existing routes until a suitable match is found
     for (var i in this.routes) {
       // do the controller & acton match?
@@ -210,8 +213,7 @@ var Router = function () {
           this.routes[i].params.action != params.action) {
         continue;
       }
-      // attempt the stringification with defaults mixed in
-      params = geddy.mixin({controller:'Application', action:'index' }, params);
+
       url = this.routes[i].stringify(params);
       if (url) {
         break;


### PR DESCRIPTION
I noticed that the redirect method on `BaseController` constructs urls based on assumptions of how routes will be laid out, rather than consulting the router, itself. This commit fixes that.
