### PR TITLE
package.json main property?

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bin": {
     "geddy": "./bin/cli.js"
   },
-  "main": "./lib",
+  "main": "./lib/geddy",
   "repository": {
     "type": "git",
     "url": "git://github.com/mde/geddy.git"


### PR DESCRIPTION
More of a question then a pull request.

Your `package.json` main property points to `./lib/`. This is a folder, which contains no `index.js` file, so appears nothing is returned.

Is this intended? 
