### PR TITLE
Repairing todo_mongo example

### DIFF
--- a/examples/todo_app_mongo/config/development.js
+++ b/examples/todo_app_mongo/config/development.js
@@ -22,20 +22,9 @@ var config = {
 , hostname: null
 , port: 4000
 , sessions: {
-	server: {
-        host : 'localhost'
-      , port : 27017
-      , db : 'testDB'
-      , collection : 'sessions'
-	}
-  , store: 'mongodb'
+    store: 'memory'
   , key: 'sid'
   , expiry: 14 * 24 * 60 * 60
-  }
-, db: {
-    mongo: {
-      db: "todo"
-    }
   }
 };
 

--- a/examples/todo_app_mongo/config/environment.js
+++ b/examples/todo_app_mongo/config/environment.js
@@ -1,11 +1,14 @@
 var config = {
-
+  db: {
+    mongo: {
+      db: 'test'
+    }
+  }
+  /*
   metrics: {
     port: 4001
   }
-
+  */
 };
 
 module.exports = config;
-
-

--- a/examples/todo_app_mongo/config/init.js
+++ b/examples/todo_app_mongo/config/init.js
@@ -1,8 +1,3 @@
-var mongo = require('mongodb-wrapper');
-
-geddy.db = mongo.db('localhost', 27017, 'todo');
-geddy.db.collection('todos');
-
 // Add uncaught-exception handler in prod-like environments
 if (geddy.config.environment != 'development') {
   process.addListener('uncaughtException', function (err) {


### PR DESCRIPTION
This was pretty confusing for a few reasons, but the bug was simply some left over code from the model adaptor examples. 

I'd also love to see a package.json file in the examples, 'cause the deps were running me in circles for a while as well. If I have time, I'll work on a version of it for the todo example and pull req that too.

thanks for the great code!
