### PR TITLE
Fixed instance "saved" attribute in mongodb adapter

### DIFF
--- a/lib/model/adapters/mongo.js
+++ b/lib/model/adapters/mongo.js
@@ -156,7 +156,7 @@ var Mongo = function (config) {
         }
         // if we don't already have the to do item, save a new one
         else {
-          instance.saved = true;
+          cleanInstance.saved = instance.saved = true;
           self.collection.save(cleanInstance, function(err, docs){
             return callback(err, instance);
           });


### PR DESCRIPTION
Previously, instances were stored in the database with instance.saved = false. Even when they were obviously saved.

This commit fixes that issue. The problem was that we were setting 

``` javascript
instance.saved = true
```

and then saving  cleanInstance to the database.

Now it sets both instance.saved and cleanInstance.saved
