### PR TITLE
Grammar and spelling fixes for Geddy website

### DIFF
--- a/site/app/views/main/community.html.jade
+++ b/site/app/views/main/community.html.jade
@@ -10,8 +10,8 @@
           img(src=star.avatar_url + "&s=300")
     - }
   .span6.info
-    h3 Fork it on Github
-    p Geddy has a vibrant community of users and contributors. Check out the source on github, join the mailing list, and get a jump start on your next app.
+    h3 Fork it on GitHub
+    p Geddy has a vibrant community of users and contributors. Check out the source on GitHub, join the mailing list, and get a jump start on your next app.
     a(href="http://github.com/mde/geddy") View the source, Luke.
 .row
   - for (var i=0; i<6; i++) {
@@ -49,6 +49,6 @@
     - }
   .span6.info
     h3 Example Applications
-    p Take a look at our example apps in the Github repo. Learn how to requre authentication, hook your app up to MongoDB, or use Jade as your templating language.
+    p Take a look at our example apps in the GitHub repo. Learn how to require authentication, hook your app up to MongoDB, or use Jade as your templating language.
     a(href="http://github.com/mde/geddy/tree/master/examples") Learn by example.
 


### PR DESCRIPTION
- Requre should be spelled as require.
- GitHub is capitilized like so (see their copyright in the footer at Github).
