### PR TITLE
Handlebars hash arguments as optional arguments support

### DIFF
--- a/lib/template/adapters/handlebars.js
+++ b/lib/template/adapters/handlebars.js
@@ -49,7 +49,7 @@ Handlebars.prototype.registerHelper = function (name, helper) {
     return false;
   }
 
-  this.engine.registerHelper(name, helper);
+  this.engine.registerHelper(name, this.wrapOptions(helper));
 };
 
 Handlebars.prototype.registerHelpers = function (helpers) {
@@ -61,5 +61,40 @@ Handlebars.prototype.registerHelpers = function (helpers) {
     this.registerHelper(h, helpers[h]);
   }
 };
+
+/*
+ * In erj we can simple call function passing options hash
+ * as argument in template, but for for handlebars it's impossible,
+ * cause object hash is not mustache expression
+ *
+ * We can use optional has arguments in handlerbars for this,
+ * but will be passed inside wrapped option object {hash : { foo : 'bar', baz : 'bla' }}
+ * and template helpers in /template/helpers like urlFor
+ * is not intended to work with this. So we just unpack options and pass them
+ * to regular helper function and we can keep one set helpers with optional arguments
+ * for handlebars and other engines
+ */
+
+Handlebars.prototype.wrapOptions = function (helper) {
+  return function() {
+    var argsLen = arguments.length,
+      options = argsLen ? arguments[argsLen - 1] : null,
+      i = 0 , newArgs;
+
+    if (options && options.hash) {
+      newArgs = [];
+
+      for (;i<argsLen - 1; i++) {
+        newArgs.push(arguments[i]);
+      }
+
+      newArgs.push(options.hash);
+      return helper.apply(this, newArgs);
+    }
+    else {
+      return helper.apply(this, arguments);
+    }
+  }
+}
 
 module.exports = Handlebars;

--- a/test/templates/engines/handlebars_mustache.js
+++ b/test/templates/engines/handlebars_mustache.js
@@ -80,6 +80,19 @@ tests = {
     var html = '<p>foo</p>',
       str = '<p>{{#items}}{{foo}}{{/items}}</p>';
     assert.equal(html, render(str, {items: [{foo: 'foo'}]}));
+  },
+
+  'test hash arguments' : function () {
+    var html = 'foobar.com/main/index'
+      , tpl = "{{url host='foobar.com' controller='main' action='index'}}"
+      , helper = function(options) {
+        console.log(options);
+        return options.host + '/' + options.controller + '/' + options.action
+      }
+
+    var adapter = new Adapter({engine: 'handlebars', template: tpl});
+    adapter.registerHelper('url', helper);
+    assert.equal(html, adapter.render());
   }
 
 };


### PR DESCRIPTION
Hi,

in geddy templates helpers where are lot of usage options objects like in

function urlFor(options<String/Object>)

We can't just pass JS object as argument inside template in handlebars, 
but where are optional hash arguments for this, see handlebars documentation for reference

http://handlebarsjs.com/block_helpers.html

Issue: handlebars pass wrapped option object argument like this to geddy's function expecting plain options:
{ hash : { foo : 'bar', baz : 'bla' }}

With this fix we can use predefined geddy helpers with handlebars in clean way:

{{{urlFor host="mysite.com" controller="main" action="index" }}}
