### PR TITLE
non-protected mongodb as a sessions store

### DIFF
--- a/lib/sessions/stores/mongodb.js
+++ b/lib/sessions/stores/mongodb.js
@@ -57,8 +57,8 @@ MongoDB.prototype = new (function () {
     var port = geddy.config.sessions.server.port || 27017;
     var db = geddy.config.sessions.server.db  || 'sessionDB';
     var prefix = geddy.config.sessions.server.prefix;
-    var user = geddy.config.sessions.server.user || 'user';
-    var password = geddy.config.sessions.server.password || 'pass';
+    var user = geddy.config.sessions.server.user || null; //Nash Patel - to be able to use non protected mongodb environment as a sessions store
+    var password = geddy.config.sessions.server.password || null;
 
     sessionCollection = geddy.config.sessions.server.collection  || 'sessions';
     _key = geddy.config.sessions.key || 'sid';


### PR DESCRIPTION
I have modified lib/sessions/stores/mongodb.js so that a mongodb environment wothout user/password can be used as a sessions store. See if it makes sense to merge.
