### PR TITLE
Problem with json encoding recognition in IE9

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -29,6 +29,7 @@ var response = new function () {
       '/content_types.json').toString());
 
   this.charsets = {
+    'application/json': 'UTF-8',
     'text/javascript': 'UTF-8',
     'text/html': 'UTF-8'
   };
@@ -78,7 +79,7 @@ utils.mixin(Response.prototype, new (function () {
     var contentType = headers['Content-Type'];
     var charset = response.charsets[contentType];
     if (charset) {
-      contentType += '; charset: ' + charset;
+      contentType += '; charset='+charset;
       headers['Content-Type'] = contentType;
     }
     this.resp.statusCode = statusCode;


### PR DESCRIPTION
faced with such a problem in ie9, because this site is not working , show only static
