### PR TITLE
Allow asynchronous init scripts

### DIFF
--- a/gen/base/init.js
+++ b/gen/base/init.js
@@ -1,15 +1,18 @@
+var init = function(cb) {
+  // Add uncaught-exception handler in prod-like environments
+  if (geddy.config.environment != 'development') {
+    process.addListener('uncaughtException', function (err) {
+      var msg = err.message;
+      if (err.stack) {
+        msg += '\n' + err.stack;
+      }
+      if (!msg) {
+        msg = JSON.stringify(err);
+      }
+      geddy.log.error(msg);
+    });
+  }
+  cb();
+};
 
-// Add uncaught-exception handler in prod-like environments
-if (geddy.config.environment != 'development') {
-  process.addListener('uncaughtException', function (err) {
-    var msg = err.message;
-    if (err.stack) {
-      msg += '\n' + err.stack;
-    }
-    if (!msg) {
-      msg = JSON.stringify(err);
-    }
-    geddy.log.error(msg);
-  });
-}
-
+exports.init = init;

--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -147,6 +147,15 @@ var App = function () {
           , fileExt
           , fileBaseName
           , i = dirList.length;
+        
+        var async_calls = 1;
+        
+        var async_cb = function() {
+          async_calls--;
+          if(async_calls<=0) {
+            next();
+          }
+        };
 
         while (--i >= 0) {
           fileName = dirList[i];
@@ -158,10 +167,15 @@ var App = function () {
               // fileName is a CoffeeScript file so try to require it
               usingCoffee = usingCoffee || utils.file.requireLocal('coffee-script');
             }
-            require(path.join(cwd, 'config', fileName));
+            var initscript = require(path.join(cwd, 'config', fileName));
+            if(initscript.init) {
+              async_calls++;
+              initscript.init(async_cb);
+            }
           }
         }
-        next();
+        
+        async_cb();
       }
 
   // Run code in the app's config/after_start.js file


### PR DESCRIPTION
Was talking to @mde about this on IRC the other day. This change just looks for an `init` method in the startup script and executes that asynchronously if it finds one. Doesn't break compatibility with the synchronous `init.js` script that everyone has right now.

This will let us do async stuff like compile assets on app startup.
