### PR TITLE
Fix async init scripts being run in the wrong context

### DIFF
--- a/lib/init/local_app_init.js
+++ b/lib/init/local_app_init.js
@@ -37,12 +37,12 @@ exports.init = function (app, next) {
       // If the func has a CPS 'next' param defined in the calling
       // signature, call it with next as a callback
       if (initFunc.length == 1) {
-        initFunc(next);
+        initFunc.apply(initScript,[next]);
       }
       // If it's a sync function with no CPS 'next', just run it
       // and go next
       else {
-        initFunc();
+        initFunc.apply(initScript);
         next();
       }
     }


### PR DESCRIPTION
Fixes #373 by running the init function in the original script's context.
