### PR TITLE
Fix for broken model.Model#remove by foreign key

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -164,17 +164,26 @@ var App = function () {
 
               event = event.replace('before','').toLowerCase();
 
+              var _data;
+
               if (typeof data == 'object') {
-                data.model = model;
-                data.event = event;
-                id = data.id;
+                _data = {};
+                for (var k in data) {
+                  if (data.hasOwnProperty(k)) {
+                    _data[k] = data[k];
+                  }
+                }
+                _data.model = model;
+                _data.event = event;
+                id = _data.id;
               }
               else {
+                _data = data;
                 id = data;
               }
 
-              geddy.io.sockets.emit(model+':'+event, data);
-              geddy.io.sockets.emit(model+':'+event+':'+id, data);
+              geddy.io.sockets.emit(model+':'+event, _data);
+              geddy.io.sockets.emit(model+':'+event+':'+id, _data);
             });
           }
 


### PR DESCRIPTION
Try something like:

``` javascript
geddy.model.Post.remove({userId: this.id})
```

It will break with

``` javascript
/usr/local/lib/node_modules/geddy/node_modules/model/lib/query/query.js:184
          datatype = descr.datatype;
                          ^
TypeError: Cannot read property 'datatype' of undefined
```

Tracking this down I've found that in geddy/lib/app/index.js there's a hook on 'beforeRemove' event that changes query conditions object adding 'model' and 'event' attributes in there.
The patch is just a simple workaround for this problem.
Not sure of the best way to fix.
