### PR TITLE
Fixed restarting the cluster workers on code change

### DIFF
--- a/lib/cluster/master.js
+++ b/lib/cluster/master.js
@@ -193,10 +193,8 @@ Master.prototype = new (function () {
     , _watchFiles = function () {
         var self = this
           , dir = process.cwd()
-          , callback = function (curr, prev) {
-              if (curr.mtime.getTime() != prev.mtime.getTime()) {
-                _monitorProcesses.call(self, {manualRotate: true});
-              }
+          , callback = function (file) {
+              _monitorProcesses.call(self, {manualRotate: true});
             };
         // Watch individual files so we can compare mtimes and restart
         // on code-changes


### PR DESCRIPTION
A recent change in mde/utilities@6b8ea0395ff5e6d6f9ed9be74b639d55f03e46fc broke the file watch function. This fixes it however because mde/utilities uses `fs.watch` instead of `fs.watchFile` we can't compare the timestamps any longer.
