### PR TITLE
new setRawHeaders and optimize send methods

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -83,18 +83,23 @@ utils.mixin(Response.prototype, new (function () {
       headers['Content-Type'] = contentType;
     }
     this.resp.statusCode = statusCode;
+    this.setRawHeaders(headers);
+  };
+
+  // Custom methods
+  this.setRawHeaders = function (headers) {
     for (var p in headers) {
       this.resp.setHeader(p, headers[p]);
     }
   };
-
-  // Custom methods
+  
   this.send = function (content, statusCode, headers) {
     //var success = !errors.errorTypes[statusCode];
     var s = statusCode || 200;
     var h = headers || {};
     this.setHeaders(s, h);
-    this.finalize(content);
+    if(content) this.finalize(content);
+    else this.finish();
   };
 
   this.finalize = function (content) {


### PR DESCRIPTION
setRawHeaders() is for when you don't want to set the status code yet (think of your early controller code setting custom header, but later on you may want to return 200 or 201).

for send() quickpath if no content - no need to do content lenth computation and writes().

Here are example usage

``` javascript
    this.before(function(){
        var res = this.response;

        if ('OPTIONS' == this.request.method) {
            res.send(null,200,{
                'Content-Type': 'text/plain',
                'Access-Control-Allow-Origin': '*',
                'Access-Control-Allow-Methods': 'GET, PUT, POST, DELETE, OPTIONS',
                'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
                'Access-Control-Max-Age': 5184000   //2 months
            });

// OLD way
//            res.setHeaders(200,{
//                'Content-Type': 'text/plain',
//                'Access-Control-Allow-Origin': '*',
//                'Access-Control-Allow-Methods': 'GET, PUT, POST, DELETE, OPTIONS',
//                'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
//                'Access-Control-Max-Age': 5184000   //2 months
//            });
//            res.finish();
            return;
        }
        else {
            res.setRawHeaders({'Access-Control-Allow-Origin': '*'});
// OLD way
//            res.resp.setHeader('Access-Control-Allow-Origin', '*');
        }
    });
```
