### PR TITLE
[response/index.js] protect against undefined self.headers in sendFile

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -121,7 +121,7 @@ utils.mixin(Response.prototype, new (function () {
       }
       else {
         // include additional headers
-        var headers = utils.mixin(self.headers, opts.headers || {});
+        var headers = utils.mixin(self.headers || {}, opts.headers || {});
         headers['Content-Type'] = contentType;
         headers['Content-Length'] = stat.size || (stat.blksize * stat.blocks);
         headers['Last-Modified'] = stat.mtime.toUTCString();


### PR DESCRIPTION
Noticed on certain page requests that the self.headers object in response.sendFile was undefined. I figured a quick fix was to protect against this inline. However, if there is a higher level fix, that's cool too.
