### PR TITLE
Fixed initialization error for realtime remove event

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -185,8 +185,6 @@ var App = function () {
                 data = JSON.stringify(data);
               }
 
-              console.log("ID: " + id);
-              console.log("Data: " + data);
               geddy.io.sockets.emit(model + ':' + ev, data);
               geddy.io.sockets.emit(model + ':' + ev + ':' + id, data);
             });


### PR DESCRIPTION
Symptom: When following the realtime demo here: https://github.com/mde/geddy/wiki/Realtime-and-MVC#lets-generate-an-app and loading up the 'things' index page on two browsers and removing a thing in one browser, this error occurs in the other browser: "Uncaught Error: Syntax error, unrecognized expression: thing-{"model":"Thing","event":"remove"}".

(Realtime events for create and update work perfectly.)

Inspecting the browser side scaffold generated code, it seems that this code is expecting the removed thing's id to be the event argument.  Instead it is this: {"model":"Thing","event":"remove"}.

The id never makes it into the object because "data" is undefined at this point in code: https://github.com/mde/geddy/blob/master/lib/app/index.js#L181

My fix corrects this; however, it still does not make an object of the form expected by the browser side generated realtime scaffolding.  I now get this error: Uncaught Error: Syntax error, unrecognized expression: #thing-{"id":"D64924A9-8043-48A3-BD64-660AB1CAE891","model":"Thing","event":"remove"} 

But at least the id is in the data and I can pull it out and delete the appropriate HTML element loaded in the browser by modifying the generated JavaScript minimally.
