### PR TITLE
Fixes an issue where removing with a query object would cause an error

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -171,11 +171,17 @@ var App = function () {
               ev = ev.replace('before', '').toLowerCase();
 
               if (typeof d == 'object') {
-                data = d;
+                // If data is an object we have to be careful not to mutate it
+                if(typeof d.toJSON == 'function') {
+                  data = d.toJSON();
+                }
+                else {
+                  data = JSON.parse(JSON.stringify(d));
+                }
+
                 data.model = model;
                 data.event = ev;
                 id = data.id;
-                data = data.toJSON();
               }
               else {
                 id = d;


### PR DESCRIPTION
Thanks @zerocle for reporting this

Fixes this issue: https://github.com/zerocle/GeddyMultiDeleteError

Not yet merging this one in because I'm not sure if creating a copy of the argument is the best way to fix this.

Since model sends the object to the event handler, so there's the chance that the user (in this case geddy) changes that object and screws up what model expected.

Also, I feel like it should be model's job to perform the copy before passing it as an argument to emit.

Thoughts @mde?
