### PR TITLE
Add a standard way to create js module for client and server side use

### DIFF
--- a/gen/base/gitignore.txt
+++ b/gen/base/gitignore.txt
@@ -7,3 +7,4 @@ log/
 npm-debug.log
 config/secrets.json
 public/js/core/models.js
+public/js/core/helpers.js

--- a/lib/init/build.js
+++ b/lib/init/build.js
@@ -2,7 +2,15 @@ var utils = require('utilities')
   , path = require('path')
   , fs = require('fs');
 
-exports.init = function (app, callback) {
+var init = function (app, callback) {
+
+  setupModels(app);
+  setupSharedHelpers(app);
+
+  return callback();
+};
+
+var setupModels = function(app) {
   var modelDir = path.join('app/models')
     , cwd = process.cwd()
     , models
@@ -13,19 +21,42 @@ exports.init = function (app, callback) {
     , jsPat = /\.js$/;
 
   // May be running totally model-less
-  if (!utils.file.existsSync(path.join(cwd, modelDir))) {
-    return callback();
+  if (utils.file.existsSync(path.join(cwd, modelDir))) {
+    models = utils.file.readdirR(modelDir)
+    models.forEach(function (item) {
+      if (jsPat.test(item)) {
+        content = fs.readFileSync(item, 'utf8');
+        files.push("(function () {\n" + content + "}());");
+      }
+    });
+    built = files.join('\n\n');
+    geddy.file.mkdirP(path.join('public/js/core'));
+    fs.writeFileSync('public/js/core/models.js', built);
   }
+}
 
-  models = utils.file.readdirR(modelDir)
-  models.forEach(function (item) {
-    if (jsPat.test(item)) {
-      content = fs.readFileSync(item, 'utf8');
-      files.push("(function () {\n" + content + "}());");
-    }
-  });
-  built = files.join('\n\n');
-  geddy.file.mkdirP(path.join('public/js/core'));
-  fs.writeFileSync('public/js/core/models.js', built);
-  return callback();
-};
+var setupSharedHelpers = function(app) {
+  var helperDir = path.join('app/helpers')
+    , cwd = process.cwd()
+    , helpers
+    , files = []
+    , file
+    , content
+    , built
+    , jsPat = /\.shared.js$/;
+
+  if (utils.file.existsSync(path.join(cwd, helperDir))) {
+    helpers = utils.file.readdirR(helperDir)
+    helpers.forEach(function (item) {
+      if (jsPat.test(item)) {
+        content = fs.readFileSync(item, 'utf8');
+        files.push("(function () {\n" + content + "}());");
+      }
+    });
+    built = files.join('\n\n');
+    geddy.file.mkdirP(path.join('public/js/core'));
+    fs.writeFileSync('public/js/core/helpers.js', built);
+  }
+}
+
+exports.init = init;


### PR DESCRIPTION
Emulating the way the models are bundled for client side use, I've updated build.js to bundle up any xxx.shared.js files in app/helpers and publish them to public/js/core/helpers.js.  

To test, create a file called test.shared.js in app/helpers and add this code to it:

```
if(typeof exports == 'undefined'){
  var exports = this['helpers'] = {};
}
exports.testSharedHelpers = function() {
  return '---------------Testing shared helpers---------------';
};
```

Add this line to the appropriate place in app/views/layouts/layout_header.html.ejs (or whatever templating you are using):

```
<%- scriptLink('/js/core/helpers.js', {type: 'text/javascript'}) %>
```

Add this require and line of code somewhere server-side (I used config/init.js):

```
var sharedHelperTest = require('../app/helpers/test.shared.js');
...
  console.log(sharedHelperTest.testSharedHelpers());
...
```

Start geddy and look for the console.log output server side.

Load up your app in a browser and type the following at the js console prompt:

```
console.log(helpers.testSharedHelpers());
```

Look for the console.log output client side.

If you like this functionality, I hope you will comment on the following:
1. Should I add the scriptLink to all the layout header templates or leave it like it is and let the developer add it as needed?
2. If so, should I use gen/base/realtime/views/xxx/layouts/layout_header.html.ejs or gen/base/views/xxx/layouts/layout_header.html.ejs
3. This whole thing could also be done by adding a new directory somewhere (app/shared_helpers?) and bundling everything in there (as opposed to specially named files in app/helpers), but this would require touching generator code and may have ramifications beyond a geddy noob's (that's me) understanding.
4. Is the way I've done this tied up with realtime in such a way that it is not available without turning on realtime (and if so, does anyone care)?
