### PR TITLE
Added some code generation that hangs the helpers off the geddy global in the client and also handles the exports issue

### DIFF
--- a/lib/init/build.js
+++ b/lib/init/build.js
@@ -41,6 +41,12 @@ var setupSharedHelpers = function(app) {
     , helpers
     , files = []
     , file
+    , exportsDef = "if(typeof exports == 'undefined') {\n" +
+                   "  if(typeof this.geddy['helpers'] == 'undefined') {\n" +
+                   "    this.geddy['helpers'] = {};\n" +
+                   "  }\n" +
+                   "  var exports = this.geddy['helpers'];\n" +
+                   "}\n"
     , content
     , built
     , jsPat = /\.shared.js$/;
@@ -50,7 +56,7 @@ var setupSharedHelpers = function(app) {
     helpers.forEach(function (item) {
       if (jsPat.test(item)) {
         content = fs.readFileSync(item, 'utf8');
-        files.push("(function () {\n" + content + "}());");
+        files.push("(function () {\n" + exportsDef + content + "}());");
       }
     });
     built = files.join('\n\n');


### PR DESCRIPTION
This is a continuation of pull request #516.

Now the shared helper file (e.g. app/helpers/test.shared.js) looks like this:

```
exports.testSharedHelpers = function() {
  return '---------------Testing shared helpers---------------';
};
```

And the client side access looks like this:

```
console.log(geddy.helpers.testSharedHelpers());
```

Definitely cleaner.  Thanks for the suggestions.
