### PR TITLE
Adding dates to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 ### 0.11
+2013-11-05
 + New Model adapters: MySQL, SQLite, LevelDB, Filesystem
 + Streaming query results from Model
 + Model adapters require local installation of DB lib in app
@@ -13,6 +14,7 @@
 + Fixed numeric property 'failbotage'
 
 ### 0.10
+2013-09-16
 + Response API (i.e., `respond`/`respondTo`/`respondWith`)
 + Customizable error pages
 + API-formatted error responses
@@ -24,6 +26,7 @@
 + Using tlsopts for parsing SSL and SPDY options
 
 ### 0.9
+2013-07-08
 + Migrations for SQL databases
 + Custom validation scenarios
 + Integrated flash messages with generated scaffold-code
@@ -41,6 +44,7 @@
 + Proper branch support for Docs site
 
 ### 0.8
+2013-04-25
 + Flash-messages for session
 + Through-associations for models
 + Eager-loading model associations for SQL adapters
@@ -60,6 +64,7 @@
 + Massive refactor of app-loading code
 
 ### 0.7
+2013-03-12
 + Node v0.10 compatibility
 + Better CLI help
 + RT code for non-EJS templating
@@ -76,6 +81,7 @@
 + Better docs for Heroku and NodeJitsu deploy
 
 ### 0.6
+2012-11-05
 + Models can now be used on the front end
 + Added the `-rt` option for app generation
 + Added realtime system to models
@@ -88,6 +94,7 @@
 + Fixed a ton more bugs (keep 'em coming!)
 
 ### 0.5
+2012-10-11
 + Brand new Web site with extensive docs
 + Removed models from geddy core, moved into Model project
 + Removed utilities from geddy core, moved into Utilities project


### PR DESCRIPTION
I used `git log --date-order --graph --tags --simplify-by-decoration
--pretty=format:'%ai %h %d'` to figure out when the first commit for
each version was.
I think adding dates to the changelog is useful for new users for many
reasons, including judging progress of the project.
