### PR TITLE
changed deprectated !!! to doctype in jade layout templates

### DIFF
--- a/gen/base/realtime/views/jade/layouts/layout_header.html.jade
+++ b/gen/base/realtime/views/jade/layouts/layout_header.html.jade
@@ -1,4 +1,4 @@
-!!! html
+doctype html
 html(lang="en")
   head
     meta(charset="utf-8")

--- a/gen/base/views/jade/layouts/layout_header.html.jade
+++ b/gen/base/views/jade/layouts/layout_header.html.jade
@@ -1,4 +1,4 @@
-!!! html
+doctype html
 html(lang="en")
   head
     meta(charset="utf-8")

--- a/gen/scaffold/views/jade/layout.html.jade.ejs
+++ b/gen/scaffold/views/jade/layout.html.jade.ejs
@@ -1,4 +1,4 @@
-!!! html
+doctype html
 html(lang="en")
   head
     meta(charset="utf-8")

--- a/gen/views/jade/layout.html.jade.ejs
+++ b/gen/views/jade/layout.html.jade.ejs
@@ -1,4 +1,4 @@
-!!! html
+doctype html
 html(lang="en")
   head
     meta(charset="utf-8")


### PR DESCRIPTION
I submitted a bug report earlier about this and I figured I would just go ahead and fix it. The latest version of jade fails entirely due to the !!! doctype shortcut being depreciated. It's just a minor fix. I'm new to Geddy so sorry if I missed any spots, but I think I got all of the layout templates.
