### PR TITLE
Added ability to prepend to outputted HTML source paths

### DIFF
--- a/lib/base_config.js
+++ b/lib/base_config.js
@@ -50,6 +50,8 @@ config = {
 , heartbeatWindow: 20000
 // Place to look for static content to serve in dev-mode
 , staticFilePath: path.normalize(cwd + '/public')
+// Name of the directory to prepend to static file URLs
+, staticSourceDir: ''
 // static file cache control
 , cacheControl: {
   // should contain mime-types as keys and expiration time in seconds

--- a/lib/template/helpers/index.js
+++ b/lib/template/helpers/index.js
@@ -16,6 +16,7 @@
  *
 */
 var utils = require('utilities')
+  , path = require('path')
   , helperUtils = require('./utils')
   , flashUtils = require('./flash')
   , Data;
@@ -68,6 +69,21 @@ exports.urlFor = {
   name: 'urlFor',
   action: function (options) {
     return helperUtils.urls.urlFor(options);
+  }
+}
+
+/**
+  @name helpers#sourcePath
+  @public
+  @function
+  @return {String} A full path to a static file
+  @description Returns a url including the source directory specified in config
+  @param {String} source The base URL path
+*/   
+exports.sourcePath = {
+  name: 'sourcePath',
+  action: function(source) {
+    return path.normalize(path.join('/', geddy.config.staticSourceDir, source));
   }
 }
 
@@ -160,7 +176,7 @@ exports.scriptLink = {
   name: 'scriptLink',
   action: function (source, htmlOptions) {
     htmlOptions = htmlOptions || {};
-    htmlOptions = utils.mixin({ src: source }, htmlOptions)
+    htmlOptions = utils.mixin({ src: exports.sourcePath.action(source) }, htmlOptions)
 
     return exports.contentTag.action('script', '', htmlOptions);
   }
@@ -180,7 +196,7 @@ exports.styleLink = {
   action: function (source, htmlOptions) {
     htmlOptions = htmlOptions || {};
 
-    return exports.contentTag.action('link', source, htmlOptions);
+    return exports.contentTag.action('link', exports.sourcePath.action(source), htmlOptions);
   }
 };
 
@@ -222,7 +238,7 @@ exports.imageTag = {
       } else delete htmlOptions.size;
     }
 
-    return exports.contentTag.action('img', source, htmlOptions);
+    return exports.contentTag.action('img', exports.sourcePath.action(source), htmlOptions);
   }
 }
 


### PR DESCRIPTION
In my team's use of Geddy we ran into an issue where wanted to be able to version our static files with each release. We want to prepend a version directory to every outputted source path generated by view helpers. I thought that modifying the `staticFilePath` would be the right way to go about this, but it seems like that refers to the directory on the server where static files are stored rather than to the path the client sees.  So, I created a new config variable `staticSourceDir`, and modified the view helpers that output a source path to look at that variable's value.  How does it look?
