### PR TITLE
Allow to disable build

### DIFF
--- a/lib/init/build.js
+++ b/lib/init/build.js
@@ -5,7 +5,7 @@ var utils = require('utilities')
 var init = function (app, callback) {
   
   if (app.config.disableBuild) {
-    return;
+    return callback();
   }
 
   setupModels(app);


### PR DESCRIPTION
The build triggers node supervisor on OpenShift, so if you don' need it, it would be nice if it could be turned off.
