### PR TITLE
Fixed bug with generation of asset URL when running server on MS Windows

### DIFF
--- a/lib/template/helpers/index.js
+++ b/lib/template/helpers/index.js
@@ -27,7 +27,8 @@ _getAssetPath = function (assetType, src) {
   var host
     , basePath
     , hasProto = /^http:\/\/|^https:\/\/|^data:/
-    , isAbs;
+    , isAbs
+    , assetPath;
 
   // Does not handle exotic protocols like SPDY, or file:// URLs
   isAbs =  hasProto.test(src) || utils.file.isAbsolute(src);
@@ -40,7 +41,12 @@ _getAssetPath = function (assetType, src) {
 
   // Include poss. extra leading slash in path.join to ensure
   // there's at least one
-  return host + path.join('/', basePath, assetType, src);
+  assetPath = host + path.join('/', basePath, assetType, src);
+
+  // If we are running server on MS Windows it generates asset paths \ instead of /
+  // some browsers (for example FF 27.0.1) is sending this symbols as %5C in GET request
+  // which results in 404 from server, but / is usable on any OS.
+  return process.platform === 'win32' ? assetPath.replace(/\\/g, '/') : assetPath;
 };
 
 


### PR DESCRIPTION
Fixed bug with generation of asset URL when running server on MS Windows it used windows specific path separator \ which is incorrect for HTTP protocol, now is using / on any OS.
