### PR TITLE
Restart workers when they crash

### DIFF
--- a/lib/cluster/master.js
+++ b/lib/cluster/master.js
@@ -370,6 +370,10 @@ Master.prototype = new (function () {
     // have exited and we can kill the master process
     if (this.processMode == processModes.SHUTDOWN) {
       this.checkShutdown();
+    } else {
+      // The worker has crashed for whatever reason, we're just
+      // going to create another one.
+      this.createWorker();
     }
   };
 


### PR DESCRIPTION
Hi there,
first of all, sorry for not providing tests.
There is no existing setup for testing this kind of thing and I have zero knowledge about testing clusters in Node.

In case of unhandled errors, workers just crash. If the last one does too, the app enters a "dull" state, swallowing connections without screaming and kicking. The only thing that can be done is to manually kill it and restart it.
I think there should be a way to automatically restart workers when they crash. This is my attempt, it's probably not the best, but it seems to be working.
