### PR TITLE
Add a "POST" example for request

### DIFF
--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -895,7 +895,15 @@ Sends requests to the given url sending any data if the method is POST or PUT
 
 #####Examples
 ```
+// 'GET' request
 request({url: 'google.com', method: 'GET'}, function (err, data) {
+  if (err) { throw err; }
+
+  console.log(data)
+})
+
+// 'POST' request
+request({url: 'google.com', data: geddy.uri.paramify({name: 'geddy', key: 'geddykey'}), headers: {'Content-Type': 'application/x-www-form-urlencoded'}, method: 'POST' }, function (err, data) {
   if (err) { throw err; }
 
   console.log(data)


### PR DESCRIPTION
It needs to set 'Content-Type' in headers explicitly, when use geddy.request to do a "POST" request.
Or else the data parameters couldn't be passed in. And there is no 'POST' example there.
So add an example for 'POST' request. it's related to Issue #604 (https://github.com/geddy/geddy/issues/604)
