### PR TITLE
Do not execute callback with unparsed JSON when failed to parse _session_store.json

### DIFF
--- a/lib/sessions/stores/filesystem.js
+++ b/lib/sessions/stores/filesystem.js
@@ -81,13 +81,12 @@ Filesystem.prototype = new (function () {
       data = d.toString();
       try {
         data = JSON.parse(data);
+        callback(null, data);
       }
       catch (e) {
         console.error('Could not parse session store, using empty session');
         callback(null, {});
       }
-
-      callback(null, data);
     });
   };
 


### PR DESCRIPTION
I updated to Geddy 13.0.7 and got following error when I open a page.

```
Could not parse session store, using empty session
[Thu, 06 Nov 2014 09:57:02 GMT] ERROR 127.0.0.1 - - [Thu Nov 06 2014 18:57:02 GMT+0900 (JST)] "GET / 1.1" 500 1031 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:33.0) Gecko/20100101 Firefox/33.0"
TypeError: Cannot set property 'accessTime' of undefined
at set (/home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/sessions/index.js:135:20)
at utils.mixin.beginOutput (/home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/controller/base_controller.js:508:20)
at utils.mixin.output (/home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/controller/base_controller.js:537:10)
at cb (/home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/controller/base_controller.js:659:16)
at /home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/template/partial.js:146:13
at Partial.renderChildren (/home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/template/partial.js:152:7)
at handleData (/home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/template/partial.js:100:16)
at /home/phanect/.nvm/v0.10.33/lib/node_modules/geddy/lib/template/partial.js:117:9
at fs.js:271:14
at Object.oncomplete (fs.js:107:15)
```

The cause is old _session_store.json. The content of _session_store.json was invalid JSON.
The content was:

```
""SiZHqfYjR6eSOJbmaHR1kAlPAEHJK8EG8tWOAuwJJf8j7BRwVbNuwVZ22Gg245kWpgfzGBqXAy3w2sjx38WF4ByqAWcg0HM6IjxzZdLIQklJoXDETU0DFh27OiYFxkfg":{"accessTime":1415166423222,"flashMessages":{}}}
```

So `JSON.parse` in _getDatastore is failed and go to catch block. `callback(null, {});` is executed.
However, there is `callback(null, data);` after it and it is executed.

Then unparsed data is passed to the callback function as an argument, and above error occured.
