### PR TITLE
Check existence of Controller class name

### DIFF
--- a/lib/init/controller.js
+++ b/lib/init/controller.js
@@ -60,6 +60,11 @@ module.exports = new (function () {
     for (var i = 0; i < dirList.length; i++) {
       item = dirList[i];
       ctor = require(item.filePath)[item.ctorName];
+      
+      if (!ctor) {
+        throw new Error(['`require(\"', item.filePath, '\")[', item.ctorName, ']` returned null.'].join(""));
+      }
+      
       ctor.origPrototype = ctor.prototype;
       if (item.ctorName != 'Application') {
         controller.register(item.ctorName, ctor);


### PR DESCRIPTION
If conrtoller name is different from naming rule, error occurs with inappropriate error message.
e.g. If file name is paper.js, class name should be Papers, but if class name Paper, error occurs.
