### PR TITLE
added support for nodemailer transport plugins

### DIFF
--- a/lib/init/mailer.js
+++ b/lib/init/mailer.js
@@ -7,10 +7,16 @@ module.exports = new (function () {
       , msg
       , transport;
     if (cfg) {
-      msg = 'Geddy mailer support requires Nodemailer. Try `npm install nodemailer`.'
+      msg = 'Geddy mailer support requires Nodemailer. Try `npm install nodemailer`.';
       mailer = utils.file.requireLocal('nodemailer', msg);
       transport = cfg.transport;
-      app.mailer = mailer.createTransport(transport.type, transport.options);
+      if(cfg.require) {
+        msg = 'You have configured a 3rd party nodemailer transport. Try `npm install ' + cfg.require + '`.';
+        plugin = utils.file.requireLocal(cfg.require, msg);
+        app.mailer = mailer.createTransport(plugin(transport.options));
+      } else {
+        app.mailer = mailer.createTransport(transport.type, transport.options);
+      }
     }
     callback();
   };


### PR DESCRIPTION
You can use the sendgrid transport plugin by configuring mailer like so:
```javascript
    , mailer: {
        fromAddressUsername: 'noreply'
        , transport: {
            type: 'sendgrid'
            , options: {
                auth: {
                    api_user: 'sendgrid username',
                    api_key: 'sendgrid password'
                }
            }
        }
        , require: 'nodemailer-sendgrid-transport' //nodemailer transport plugin npm package name
    }
```