### PR TITLE
Fix bug that error message is not shown

### DIFF
--- a/lib/response/errors.js
+++ b/lib/response/errors.js
@@ -65,7 +65,7 @@ errors = new function () {
         Error.captureStackTrace(this, this.constructor);
       }
     };
-    errorConstructor.prototype = new Error();
+    errorConstructor.prototype = Object.create(Error.prototype);
     errorConstructor.prototype.constructor = errorConstructor;
 
     return errorConstructor;

--- a/test/response/errors.js
+++ b/test/response/errors.js
@@ -1,0 +1,12 @@
+var assert = require('assert')
+  , errors = require('../../lib/response/errors');
+
+module.exports = {
+  'Error object is properly created': function () {
+    var err = new errors.ForbiddenError('Cross-site request not allowed.');
+
+    assert.equal(err.statusCode, 403);
+    assert.equal(err.statusText, 'Forbidden');
+    assert.equal(err.message, 'Cross-site request not allowed.');
+  }
+};


### PR DESCRIPTION
Before this change:
Error message is not shown and stacktrace is useless.

```sh
Error
    at createConstructor (/home/phanect/dev/notel-api/node_modules/geddy/lib/response/errors.js:68:34)
    at new <anonymous> (/home/phanect/dev/notel-api/node_modules/geddy/lib/response/errors.js:79:33)
    at Object.<anonymous> (/home/phanect/dev/notel-api/node_modules/geddy/lib/response/errors.js:21:10)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/home/phanect/dev/notel-api/node_modules/geddy/lib/controller/responder/index.js:6:14)
```

After this change:
Error cause is properly pointed out.

```sh
ReferenceError: self is not defined
    at before.except (/home/phanect/dev/notel-api/app/controllers/application.js:34:4)
    at null.<anonymous> (/home/phanect/dev/notel-api/node_modules/geddy/lib/controller/base_controller.js:178:17)
    at async.AsyncBase.runItem (/home/phanect/dev/notel-api/node_modules/utilities/lib/async.js:115:10)
    at async.AsyncBase.next (/home/phanect/dev/notel-api/node_modules/utilities/lib/async.js:120:12)
    at /home/phanect/dev/notel-api/node_modules/utilities/lib/async.js:155:54
    at process._tickDomainCallback (node.js:381:11)
```
I refered an [MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Example.3A_Custom_Error_Types) to fix this.