### PR TITLE
Add Node 0.12 & io.js support and strict mode support to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - npm install https://github.com/mde/model/archive/master.tar.gz
   - npm install https://github.com/mde/utilities/archive/master.tar.gz
 
-script: node_modules/jake/bin/cli.js test --trace
+script: node --use_strict node_modules/jake/bin/cli.js test --trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.10"
+  - "iojs"
 
 before_install:
   - npm update -g npm


### PR DESCRIPTION
I believe everyone can agree with 0.12 support, but I want to hear opinion about io.js support and strict mode test.