### PR TITLE
Don't assign value to params.controller when params === false

### DIFF
--- a/lib/app/request_helpers.js
+++ b/lib/app/request_helpers.js
@@ -94,8 +94,11 @@
 
   , getParams: function (router, reqUrl, method) {
       var params = router.first(reqUrl, method);
-      params.controller = utils.string.camelize(params.controller,
+
+      if (params) {
+        params.controller = utils.string.camelize(params.controller,
           {initialCap: true});
+      }
       return params;
     }
   };


### PR DESCRIPTION
Fix #679. This error occurs on Node.js 0.12 and io.js.

When there is no params in the `reqUrl`, Barista's router.first returns `false`.
In this case, it is of course inappropriate to assign value to `params.controller`, but it is allowed until Node.js 0.10.
(On Node.js 0.10, it is ignored to assign `params.controller` and `params` is `false` at last.)

```javascript
, getParams: function (router, reqUrl, method) {
    var params = router.first(reqUrl, method);
    console.log(params); // false
    params.controller = utils.string.camelize(params.controller, // Error; assigning value to false.controller
        {initialCap: true});
    return params;
  }
```