### PR TITLE
Issue #723: Update README.md to state the compatible node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Geddy
+**`node "~> 5.12.0"`**
 #### A simple, structured web framework for Node
 
 [![Build Status](https://travis-ci.org/geddy/geddy.png?branch=master)](https://travis-ci.org/geddy/geddy) [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/geddy/geddy)


### PR DESCRIPTION
To point out that Geddy only works up to Node version 5.12.0.