### PR TITLE
Add contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+> Please read these instructions carefully
+
+**Pointers:**
+
+- A basic understanding of git branching is required.
+- Do not commit changes on the 'master' branch.
+- Do not merge any branches.
+- We will take care of merging, bumping up the version number, changelog, and tagging.
+
+If you do not follow those principles. Your pull request will be rejected. We would like to maintain a clean repo to work in, and try avoid headaches :laughing:
+
+> **For Admins:**
+> - Make sure to merge using the `--no-ff` flag. This is so we can see where the commits originally came from by avoiding fast-forwarding.
+> - Make sure to merge hotfixes into 'develop' as well as 'master'.
+> - Create a 'release-[next version]' branch before merging 'develop' into 'master'.
+>   **Process:**
+>   - `$ git checkout -b release-[next version] develop` i.e. v16.0.3
+>   - Bump up the version number in the `package.json` file (without the 'v') and commit the change.
+>   - Update the `CHANGELOG.md` file. Look back through the commit history to help you.
+>   - Apply bug fixes **(optional)**
+>   - `$ git checkout master`
+>   - `$ git merge --no-ff release-[version number]`
+>   - `$ git tag -a [version number]` **(Required)** In the tag message, name it and follow with a list of highlighted changes. It should match what was written in the changelog.
+>   - `$ git checkout develop`
+>   - `$ git merge --no-ff release-[version number]`
+>   - `$ git branch -d release-[version number]`
+>   - When pushing the changes to the repo, remember to push the tag as well:
+>     `$ git push origin <tag_name>`
+
+## Branch structure:
+
+### master:
+
+This is the production branch. Do not make any commits here. We will merge the relevant branch if it is accepted.
+
+### develop:
+
+Here you can odd commits. When creating a pull request, point to this branch.
+
+### feature-[the feature you are adding]:
+
+These are feature branches.
+
+If you have a feature you would like to add, that is likely to have many commits, then please create a feature branch and point to this branch when creating a pull request.
+
+> **Note:**
+> Make sure to branch off from the 'develop' branch, using:
+>
+> `$ git checkout -b feature-[the feature you are adding] develop`
+
+### hotfix-[next version]
+
+These are for quick (important) fixes. Please place the incremented version number into the branch name. It is in the format [vMAJOR.MINOR.HOTFIX]. So if the current version is 'v15.2.3', you would write:
+
+`$ git checkout -b hotfix-v15.2.4 master`.
+
+> **Note:**
+> These must branch off the 'master' branch, as it is something on the 'master' branch you are attempting to fix. Do not create hotfix branches for the 'develop' branch, as it can be committed directly onto the 'develop' branch.
+
+---
+
+Any questions, create an 'issue'. We would rather make sure that you grasp the branching correctly, instead of creating a load of commits on the wrong branch that you will then need to migrate to another branch.
+
+---
+
+If you would like to read up on this branching model, please follow [this link][1].
+
+:octocat:
+
+[1]: http://nvie.com/posts/a-successful-git-branching-model/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ These are for quick (important) fixes. Please place the incremented version numb
 
 ---
 
-Any questions, create an 'issue'. We would rather make sure that you grasp the branching correctly, instead of creating a load of commits on the wrong branch that you will then need to migrate to another branch.
+Any questions, create an 'issue'. We would rather make sure that you grasp the branching correctly, instead of creating a load of commits on the wrong branch that you will then need to migrate to another branch. If we have time, we might be able to make the changes ourselves if you describe what you are trying to achieve.
 
 If you would like to read up on this branching model, please follow [this link][1].
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ If you do not follow those principles. Your pull request will be rejected. We wo
 >   - `$ git branch -d release-[version number]`
 >   - When pushing the changes to the repo, remember to push the tag as well:
 >     `$ git push origin <tag_name>`
+> - Make sure to delete release, feature and hotfix branches once they have been merged. This will stop branch clutter.
 
 ## Branch structure:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,24 +11,7 @@
 
 If you do not follow those principles. Your pull request will be rejected. We would like to maintain a clean repo to work in, and try avoid headaches :laughing:
 
-> **For Admins:**
-> - Make sure to merge using the `--no-ff` flag. This is so we can see where the commits originally came from by avoiding fast-forwarding.
-> - Make sure to merge hotfixes into 'develop' as well as 'master'.
-> - Create a 'release-[next version]' branch before merging 'develop' into 'master'.
->   **Process:**
->   - `$ git checkout -b release-[next version] develop` i.e. v16.0.3
->   - Bump up the version number in the `package.json` file (without the 'v') and commit the change.
->   - Update the `CHANGELOG.md` file. Look back through the commit history to help you.
->   - Apply bug fixes **(optional)**
->   - `$ git checkout master`
->   - `$ git merge --no-ff release-[version number]`
->   - `$ git tag -a [version number]` **(Required)** In the tag message, name it and follow with a list of highlighted changes. It should match what was written in the changelog.
->   - `$ git checkout develop`
->   - `$ git merge --no-ff release-[version number]`
->   - `$ git branch -d release-[version number]`
->   - When pushing the changes to the repo, remember to push the tag as well:
->     `$ git push origin <tag_name>`
-> - Make sure to delete release, feature and hotfix branches once they have been merged. This will stop branch clutter.
+---
 
 ## Branch structure:
 
@@ -62,9 +45,28 @@ These are for quick (important) fixes. Please place the incremented version numb
 
 ---
 
-Any questions, create an 'issue'. We would rather make sure that you grasp the branching correctly, instead of creating a load of commits on the wrong branch that you will then need to migrate to another branch.
+> **For Admins:**
+> - Make sure to merge using the `--no-ff` flag. This is so we can see where the commits originally came from by avoiding fast-forwarding.
+> - Make sure to merge hotfixes into 'develop' as well as 'master'.
+> - Create a 'release-[next version]' branch before merging 'develop' into 'master'.
+>   **Process:**
+>   - `$ git checkout -b release-[next version] develop` i.e. v16.0.3
+>   - Bump up the version number in the `package.json` file (without the 'v') and commit the change.
+>   - Update the `CHANGELOG.md` file. Look back through the commit history to help you.
+>   - Apply bug fixes **(optional)**
+>   - `$ git checkout master`
+>   - `$ git merge --no-ff release-[version number]`
+>   - `$ git tag -a [version number]` **(Required)** In the tag message, name it and follow with a list of highlighted changes. It should match what was written in the changelog.
+>   - `$ git checkout develop`
+>   - `$ git merge --no-ff release-[version number]`
+>   - `$ git branch -d release-[version number]`
+>   - When pushing the changes to the repo, remember to push the tag as well:
+>     `$ git push origin <tag_name>`
+> - Make sure to delete release, feature and hotfix branches once they have been merged. This will stop branch clutter.
 
 ---
+
+Any questions, create an 'issue'. We would rather make sure that you grasp the branching correctly, instead of creating a load of commits on the wrong branch that you will then need to migrate to another branch.
 
 If you would like to read up on this branching model, please follow [this link][1].
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Geddy
+
 **`node "~> 5.12.0"`**
+
 #### A simple, structured web framework for Node
 
 [![Build Status](https://travis-ci.org/geddy/geddy.png?branch=master)](https://travis-ci.org/geddy/geddy) [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/geddy/geddy)
 
-#### Install Geddy:
+## Install Geddy:
 
 ```
 $ npm install -g geddy
 ```
 
-#### Create an app, start it up:
+## Create an app, start it up:
 
 ```
 $ geddy gen app my_app
@@ -20,7 +22,7 @@ Creating 1 worker process.
 Server worker running in development on port 4000
 ```
 
-#### Create a CRUD resource
+## Create a CRUD resource
 
 ```
 $ geddy gen scaffold foobar baz:string qux:int
@@ -33,25 +35,25 @@ $ geddy gen scaffold foobar baz:string qux:int
 [Added] View templates
 ```
 
-#### Documentation
+## Documentation
 
 Docs are on the GeddyJS Website: http://geddyjs.org/documentation
 
-#### Community Tutorials
+## Community Tutorials
 
 Geddy.JS: A No-Brainer MVC Node.js Framework - Bhanu Pratap Chaudhary
 https://www.digitalocean.com/community/articles/geddy-js-a-no-brainer-mvc-node-js-framework
 
-#### Community
+## Community
 
 * Mailing list: [https://groups.google.com/group/geddyjs](https://groups.google.com/group/geddyjs)
 * [Gitter](https://gitter.im/geddy/geddy)
 
-#### License
+## License
 
 Apache License, Version 2
 
 - - -
+
 Geddy Web-app development framework copyright 2112
 mde@fleegix.org.
-

--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ Docs are on the GeddyJS Website: http://geddyjs.org/documentation
 
 ## Community Tutorials
 
-Geddy.JS: A No-Brainer MVC Node.js Framework - Bhanu Pratap Chaudhary
-https://www.digitalocean.com/community/articles/geddy-js-a-no-brainer-mvc-node-js-framework
+[Geddy.JS: A No-Brainer MVC Node.js Framework](https://www.digitalocean.com/community/articles/geddy-js-a-no-brainer-mvc-node-js-framework) - Bhanu Pratap Chaudhary
 
 ## Community
 
-* Mailing list: [https://groups.google.com/group/geddyjs](https://groups.google.com/group/geddyjs)
+* [Mailing list](https://groups.google.com/group/geddyjs)
 * [Gitter](https://gitter.im/geddy/geddy)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Docs are on the GeddyJS Website: http://geddyjs.org/documentation
 * [Mailing list](https://groups.google.com/group/geddyjs)
 * [Gitter](https://gitter.im/geddy/geddy)
 
+## Contributing
+
+Contributions are definitely welcome, but we will need you to do it in an organised manner. So please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute to the project.
+
+Once you have carefully read through the contributing guidelines, fork the repo, make the changes, and open a pull request pointing to the respective branch. We will shortly get back to you.
+
+Thank you for taking time out your day to contribute :+1: :octocat:
+
 ## License
 
 Apache License, Version 2


### PR DESCRIPTION
I would like to add instructions on how to contribute to the project. I was going create an 'issue' to ask if [this](http://nvie.com/posts/a-successful-git-branching-model/) branching practice could be used from now on (or if one is being used), but I thought I would just go ahead an create it. I don't mind if the idea is rejected, as I was going to write similar instructions for my own repos.

It also details how to version number.

If you agree to accept this pull request, then please merge it to a branch named 'develop', following the new guidelines set out in [CONTRIBUTE.md](CONTRIBUTE.md) 😃 

You could increase my level of access, so I can just do it myself :wink: