### PR TITLE
Add node version and licence details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 $ npm install -g geddy
 ```
 
+> **Note:**
+> Make sure your installed node version is not v6 or higher, as Geddy will not function properly. This will be fixed in the, hopefully, soon future.
+>
+> Consider using '[nvm](https://github.com/creationix/nvm)' to help you manage your node versions.
+
 #### Create an app, start it up:
 
 ```
@@ -54,4 +59,3 @@ Apache License, Version 2
 - - -
 Geddy Web-app development framework copyright 2112
 mde@fleegix.org.
-

--- a/README.md
+++ b/README.md
@@ -54,8 +54,22 @@ https://www.digitalocean.com/community/articles/geddy-js-a-no-brainer-mvc-node-j
 
 #### License
 
-Apache License, Version 2
+Copyright 2017. Geddy - Web-app development framework
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 - - -
-Geddy Web-app development framework copyright 2112
-mde@fleegix.org.
+
+mde@fleegix.org
+
+:octocat:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "version": "13.0.8",
   "author": "Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)",
+  "license": "Apache 2.0",
   "dependencies": {
     "barista": "0.2.x",
     "chalk": "^0.4.0",


### PR DESCRIPTION
This will update the [README.md](README.md) with clearer details on which node version to use and the project licence. It will fix the 'WARN' message about the missing `license` entry when `npm install` is run.

Please merge this into the branch called 'develop', if my other pull request is accepted (#728).